### PR TITLE
Dan/parachain param getters

### DIFF
--- a/src/apis/constants.ts
+++ b/src/apis/constants.ts
@@ -1,0 +1,109 @@
+import { Balance, BalanceOf, BlockNumber, Moment, RuntimeDbWeight, Weight } from "@polkadot/types/interfaces/runtime";
+import { DOT } from "@interlay/polkabtc/interfaces/default";
+import { ApiPromise } from "@polkadot/api";
+import { u32, u64 } from "@polkadot/types/primitive";
+import { Vec } from "@polkadot/types/codec";
+import { WeightToFeeCoefficient } from "@polkadot/types/interfaces/support";
+
+export interface ConstantsAPI {
+    getDotExistentialDeposit(): Balance;
+    getIssuePeriod(): BlockNumber;
+    getPolkaBtcExistentialDeposit(): Balance;
+    getReplacePeriod(): BlockNumber;
+    getStakedRelayersMaturityPeriod(): BlockNumber;
+    getStakedRelayersMinimumDeposit(): DOT;
+    getStakedRelayersMinimumParticipants(): u64;
+    getStakedRelayersMinimumStake(): DOT;
+    getStakedRelayersVoteThreshold(): u64;
+    getStakedRelayersVotingPeriod(): BlockNumber;
+    getSystemBlockExecutionWeight(): Weight;
+    getSystemBlockHashCount(): BlockNumber;
+    getSystemDbWeight(): RuntimeDbWeight;
+    getSystemExtrinsicBaseWeight(): Weight;
+    getSystemMaximumBlockLength(): u32;
+    getSystemMaximumBlockWeight(): Weight;
+    getTimestampMinimumPeriod(): Moment;
+    getTransactionByteFee(): BalanceOf;
+    getTransactionWeightToFee(): Vec<WeightToFeeCoefficient>;
+}
+
+export class DefaultConstantsAPI implements ConstantsAPI {
+    constructor(private api: ApiPromise) {}
+
+    getDotExistentialDeposit(): Balance {
+        return this.api.consts.dot.existentialDeposit;
+    }
+
+    getIssuePeriod(): BlockNumber {
+        return this.api.consts.issue.issuePeriod;
+    }
+
+    getPolkaBtcExistentialDeposit(): Balance {
+        return this.api.consts.polkaBtc.existentialDeposit;
+    }
+
+    getReplacePeriod(): BlockNumber {
+        return this.api.consts.replace.replacePeriod;
+    }
+
+    getStakedRelayersMaturityPeriod(): BlockNumber {
+        return this.api.consts.stakedRelayers.maturityPeriod;
+    }
+
+    getStakedRelayersMinimumDeposit(): DOT {
+        return this.api.consts.stakedRelayers.minimumDeposit;
+    }
+
+    getStakedRelayersMinimumParticipants(): u64 {
+        return this.api.consts.stakedRelayers.minimumParticipants;
+    }
+
+    getStakedRelayersMinimumStake(): DOT {
+        return this.api.consts.stakedRelayers.minimumStake;
+    }
+
+    getStakedRelayersVoteThreshold(): u64 {
+        return this.api.consts.stakedRelayers.voteThreshold;
+    }
+
+    getStakedRelayersVotingPeriod(): BlockNumber {
+        return this.api.consts.stakedRelayers.votingPeriod;
+    }
+
+    getSystemBlockExecutionWeight(): Weight {
+        return this.api.consts.system.blockExecutionWeight;
+    }
+
+    getSystemBlockHashCount(): BlockNumber {
+        return this.api.consts.system.blockHashCount;
+    }
+
+    getSystemDbWeight(): RuntimeDbWeight {
+        return this.api.consts.system.dbWeight;
+    }
+
+    getSystemExtrinsicBaseWeight(): Weight {
+        return this.api.consts.system.extrinsicBaseWeight;
+    }
+
+    getSystemMaximumBlockLength(): u32 {
+        return this.api.consts.system.maximumBlockLength;
+    }
+
+    getSystemMaximumBlockWeight(): Weight {
+        return this.api.consts.system.maximumBlockWeight;
+    }
+
+    getTimestampMinimumPeriod(): Moment {
+        return this.api.consts.timestamp.minimumPeriod;
+    }
+
+    getTransactionByteFee(): BalanceOf {
+        return this.api.consts.transactionPayment.transactionByteFee;
+    }
+
+    getTransactionWeightToFee(): Vec<WeightToFeeCoefficient> {
+        return this.api.consts.transactionPayment.weightToFee;
+    }
+
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -6,3 +6,4 @@ export { OracleAPI } from "./oracle";
 export { BTCCoreAPI } from "./btc-core";
 export { CollateralAPI } from "./collateral";
 export { TreasuryAPI } from "./treasury";
+export { ConstantsAPI } from "./constants";

--- a/test/integration/apis/constants.test.ts
+++ b/test/integration/apis/constants.test.ts
@@ -1,0 +1,154 @@
+import { ApiPromise } from "@polkadot/api";
+import { assert } from "chai";
+import { ConstantsAPI, DefaultConstantsAPI } from "../../../src/apis/constants";
+import { createPolkadotAPI } from "../../../src/factory";
+import { defaultEndpoint } from "../../config";
+
+describe("Constants", function () {
+    this.timeout(10000); // API can be slightly slow
+
+    let api: ApiPromise;
+    let constantAPI: ConstantsAPI;
+
+    beforeEach(async () => {
+        api = await createPolkadotAPI(defaultEndpoint);
+        constantAPI = new DefaultConstantsAPI(api);
+    });
+
+    afterEach(async () => {
+        await api.disconnect();
+    });
+
+    describe("getDotExistentialDeposit", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getDotExistentialDeposit();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getIssuePeriod", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getIssuePeriod();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getPolkaBtcExistentialDeposit", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getPolkaBtcExistentialDeposit();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getReplacePeriod", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getReplacePeriod();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersMaturityPeriod", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersMaturityPeriod();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersMinimumDeposit", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersMinimumDeposit();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersMinimumParticipants", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersMinimumParticipants();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersMinimumStake", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersMinimumStake();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersVoteThreshold", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersVoteThreshold();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getStakedRelayersVotingPeriod", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getStakedRelayersVotingPeriod();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemBlockExecutionWeight", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemBlockExecutionWeight();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemBlockHashCount", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemBlockHashCount();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemDbWeight", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemDbWeight();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemExtrinsicBaseWeight", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemExtrinsicBaseWeight();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemMaximumBlockLength", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemMaximumBlockLength();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getSystemMaximumBlockWeight", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getSystemMaximumBlockWeight();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getTimestampMinimumPeriod", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getTimestampMinimumPeriod();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getTransactionByteFee", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getTransactionByteFee();
+            assert.isDefined(returnValue);
+        });
+    });
+
+    describe("getTransactionWeightToFee", () => {
+        it("should sucessfully return", async () => {
+            const returnValue = await constantAPI.getTransactionWeightToFee();
+            assert.isDefined(returnValue);
+        });
+    });
+});


### PR DESCRIPTION
Creates api calls for each of the constants that are automatically generated in `src/interfaces/augment-api-consts.ts` by running the yarn `build` script. 

All these API calls are grouped in the same file, `ConstantsAPI`. The alternative would have been to add these API calls to their respective APIs if they exist (such as `IssueAPI`, `VaultsAPI`), but for many constants (such as those for `System` and `TransactionPayment`) no API exists in the lib. I considered that adding too many of these files would be messy, but am waiting for feedback on this decision