### PR TITLE
List staked relayers with id

### DIFF
--- a/src/apis/staked-relayer.ts
+++ b/src/apis/staked-relayer.ts
@@ -8,6 +8,7 @@ import { pagedIterator } from "../utils";
 
 export interface StakedRelayerAPI {
     list(): Promise<ActiveStakedRelayer[]>;
+    map(): Promise<Map<AccountId, ActiveStakedRelayer>>;
     getPagedIterator(perPage: number): AsyncGenerator<ActiveStakedRelayer[]>;
     get(activeStakedRelayerId: AccountId): Promise<ActiveStakedRelayer>;
     getStakedDOTAmount(activeStakedRelayerId: AccountId): Promise<DOT>;
@@ -32,6 +33,22 @@ export class DefaultStakedRelayerAPI implements StakedRelayerAPI {
     async list(): Promise<ActiveStakedRelayer[]> {
         const activeStakedRelayersMap = await this.api.query.stakedRelayers.activeStakedRelayers.entries();
         return activeStakedRelayersMap.map((v) => v[1]);
+    }
+
+    async map(): Promise<Map<AccountId, ActiveStakedRelayer>> {
+        const activeStakedRelayers = await this.api.query.stakedRelayers.activeStakedRelayers.entries();
+        const activeStakedRelayerPairs: [
+            AccountId,
+            ActiveStakedRelayer
+        ][] = activeStakedRelayers.map((activeStakedRelayer) => [
+            this.api.createType("AccountId", activeStakedRelayer[0]),
+            activeStakedRelayer[1],
+        ]);
+        const activeStakedRelayersMap: Map<AccountId, ActiveStakedRelayer> = new Map<AccountId, ActiveStakedRelayer>();
+        activeStakedRelayerPairs.forEach((activeStakedRelayerPair) =>
+            activeStakedRelayersMap.set(activeStakedRelayerPair[0], activeStakedRelayerPair[1])
+        );
+        return activeStakedRelayersMap;
     }
 
     getPagedIterator(perPage: number): AsyncGenerator<ActiveStakedRelayer[]> {

--- a/src/mock/apis/staked-relayer.ts
+++ b/src/mock/apis/staked-relayer.ts
@@ -4,7 +4,7 @@ import { AccountId, BlockNumber, Moment } from "@polkadot/types/interfaces/runti
 import BN from "bn.js";
 import { U8aFixed, UInt } from "@polkadot/types/codec";
 import { TypeRegistry } from "@polkadot/types";
-
+import { GenericAccountId } from "@polkadot/types/generic";
 import { StakedRelayerAPI } from "../../apis/staked-relayer";
 
 export class MockStakedRelayerAPI implements StakedRelayerAPI {
@@ -17,6 +17,15 @@ export class MockStakedRelayerAPI implements StakedRelayerAPI {
                 stake: new BN(11.9) as DOT,
             },
         ];
+    }
+
+    async map(): Promise<Map<AccountId, ActiveStakedRelayer>> {
+        const registry = new TypeRegistry();
+        const decodedAccountId = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
+        return new Map([
+            [new GenericAccountId(registry, decodedAccountId), <ActiveStakedRelayer>{ stake: new BN(10.2) as DOT }],
+            [new GenericAccountId(registry, decodedAccountId), <ActiveStakedRelayer>{ stake: new BN(11.9) as DOT }],
+        ]);
     }
 
     getPagedIterator(_perPage: number): AsyncGenerator<ActiveStakedRelayer[]> {

--- a/test/integration/apis/staked-relayer.test.ts
+++ b/test/integration/apis/staked-relayer.test.ts
@@ -8,7 +8,6 @@ import { ActiveStakedRelayer, DOT } from "../../../src/interfaces/default";
 import { assert } from "../../chai";
 import { defaultEndpoint } from "../../config";
 
-
 describe("stakedRelayerAPI", () => {
     function numberToDOT(x: number): DOT {
         return new BN(x) as DOT;
@@ -60,6 +59,11 @@ describe("stakedRelayerAPI", () => {
         //     const feesEarned = await stakedRelayerAPI.getFeesEarned();
         //     assert.notEqual(typeof(feesEarned), undefined);
         // });
+
+        it("should listIncludingIds", async () => {
+            const latestBTCBlockFromBTCRelay = await stakedRelayerAPI.map();
+            assert.isDefined(latestBTCBlockFromBTCRelay);
+        });
 
         it("should getLatestBTCBlockFromBTCRelay", async () => {
             const latestBTCBlockFromBTCRelay = await stakedRelayerAPI.getLatestBTCBlockFromBTCRelay();


### PR DESCRIPTION
Adds a new `listIncludingIds` function to the `StakedRelayerAPI`, that returns a list of [id, ActiveStakedRelayer]. The regular `list` function simply returns a list of `ActiveStakedRelayer`s