### PR TITLE
Fix tx logger promise

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
 import { AddressOrPair } from "@polkadot/api/submittable/types";
-import { SubmittableExtrinsic, ApiTypes } from "@polkadot/api/types";
-import { Callback, ISubmittableResult } from "@polkadot/types/types";
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { ISubmittableResult } from "@polkadot/types/types";
 import { EventRecord, DispatchError } from "@polkadot/types/interfaces/system";
 import { ApiPromise } from "@polkadot/api";
 
@@ -16,8 +16,18 @@ export async function sendLoggedTx(
         // signAndSend: Promise<() => void>
         // signAndSend -> signAndSend resolves (we set unsubscribe) -> callback is called
         transaction
-            .signAndSend(signer, { nonce: -1 }, (result: ISubmittableResult) => resolve({ unsubscribe, result }))
+            .signAndSend(signer, { nonce: -1 }, (result: ISubmittableResult) => callback({ unsubscribe, result }))
             .then((u: () => void) => (unsubscribe = u));
+
+        function callback(callbackObject: { unsubscribe: () => void; result: any }): void {
+            // could log events here as they are being emitted
+            // using callbackObject.result.events
+            // noting that sometimes several events are
+            // emitted at once
+            if (callbackObject.result.status.isFinalized) {
+                resolve(callbackObject);
+            }
+        }
     });
 
     console.log(`Transaction finalized at blockHash ${result.status.asFinalized}`);
@@ -28,27 +38,32 @@ export async function sendLoggedTx(
 
 function printEvents(events: EventRecord[], api: ApiPromise) {
     let foundErrorEvent = false;
-    events.flatMap(({ event }) => event.data).forEach((eventData: any) => {
-        if (eventData.isModule) {
-            try {
-                const parsedEventData = eventData as DispatchError;
-                const decoded = api.registry.findMetaError(parsedEventData.asModule);
-                const { documentation, name, section } = decoded;
-                if (documentation) {
-                    console.log(`\t${section}.${name}: ${documentation.join(" ")}`);
-                } else {
-                    console.log(`\t${section}.${name}`);
+    events
+        .flatMap(({ event }) => event.data)
+        .forEach((eventData) => {
+            if (isDispatchError(eventData)) {
+                try {
+                    const decoded = api.registry.findMetaError(eventData.asModule);
+                    const { documentation, name, section } = decoded;
+                    if (documentation) {
+                        console.log(`\t${section}.${name}: ${documentation.join(" ")}`);
+                    } else {
+                        console.log(`\t${section}.${name}`);
+                    }
+                    foundErrorEvent = true;
+                } catch (err) {
+                    console.log("\tCould not find transaction failure details.");
                 }
-                foundErrorEvent = true;
-            } catch (err) {
-                console.log("\tCould not find transaction failure details.");
             }
-        }
-    });
+        });
 
     if (!foundErrorEvent) {
         events.forEach(({ phase, event: { data, method, section } }) => {
             console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
         });
     }
+}
+
+function isDispatchError(eventData: unknown): eventData is DispatchError {
+    return (eventData as DispatchError).isModule !== undefined;
 }


### PR DESCRIPTION
The callback function passed to `signAndSend` may be called several times (although not necesarrily once for every new event). As such, the Promise only `resolves` when the `isFinalized` property of the callback object is `truthy`. 

The previous implementation worked correctly only when the the callback was called once per tx execution/settlement.