### PR TITLE
feat(vault): Add api call for fetching replace requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/polkabtc",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "JavaScript library to interact with PolkaBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@interlay/esplora-btc-api": "^0.1.7",
-    "@interlay/polkabtc-types": "^0.1.5",
+    "@interlay/polkabtc-types": "^0.1.6",
     "@types/big.js": "^4.0.5",
     "big.js": "^6.0.1",
     "bitcoinjs-lib": "^5.2.0",

--- a/src/apis/issue.ts
+++ b/src/apis/issue.ts
@@ -17,6 +17,7 @@ export interface IssueAPI {
     getGriefingCollateral(): Promise<DOT>;
     list(): Promise<IssueRequest[]>;
     getPagedIterator(perPage: number): AsyncGenerator<IssueRequest[]>;
+    mapForUser(account: AccountId): Promise<Map<H256, IssueRequest>>;
 }
 
 export class DefaultIssueAPI implements IssueAPI {

--- a/src/apis/redeem.ts
+++ b/src/apis/redeem.ts
@@ -16,6 +16,7 @@ export interface RedeemAPI {
     cancel(redeemId: H256, reimburse?: boolean): Promise<void>;
     setAccount(account?: AddressOrPair): void;
     getPagedIterator(perPage: number): AsyncGenerator<RedeemRequest[]>;
+    mapForUser(account: AccountId): Promise<Map<H256, RedeemRequest>>;
 }
 
 export class DefaultRedeemAPI {

--- a/src/apis/vaults.ts
+++ b/src/apis/vaults.ts
@@ -1,4 +1,4 @@
-import { PolkaBTC, Vault, IssueRequest, RedeemRequest } from "../interfaces/default";
+import { PolkaBTC, Vault, IssueRequest, RedeemRequest, ReplaceRequest } from "../interfaces/default";
 import { ApiPromise } from "@polkadot/api";
 import { AccountId } from "@polkadot/types/interfaces";
 import { UInt } from "@polkadot/types/codec";
@@ -79,6 +79,24 @@ export class DefaultVaultsAPI {
             redeemRequest.vault.eq(vaultId)
         );
         return new Map([[vaultId, redeemRequestsWithCurrentVault]]);
+    }
+
+    /**
+     * Fetch the replace requests associated with a vault. In the returned requests,
+     * the vault is either the replaced or the replacing one.
+     *
+     * @param vaultId - The AccountId of the vault used to filter replace requests
+     * @returns A map with a single key, from the vault AccountId to replace requests involving said vault
+     */
+    async mapReplaceRequests(vaultId: AccountId): Promise<Map<AccountId, ReplaceRequest[]>> {
+        const customAPIRPC = this.api.rpc as any;
+        try {
+            const oldVaultReplaceRequests = await customAPIRPC.replace.getOldVaultReplaceRequests(vaultId);
+            const newVaultReplaceRequests = await customAPIRPC.replace.getNewVaultReplaceRequests(vaultId);
+            return new Map([[vaultId, [...oldVaultReplaceRequests, ...newVaultReplaceRequests]]]);
+        } catch (e) {
+            return Promise.reject("Error during replace request retrieval");
+        }
     }
 
     getPagedIterator(perPage: number): AsyncGenerator<Vault[]> {

--- a/src/apis/vaults.ts
+++ b/src/apis/vaults.ts
@@ -13,6 +13,7 @@ export interface VaultsAPI {
     listPaged(): Promise<Vault[]>;
     mapIssueRequests(vaultId: AccountId): Promise<Map<AccountId, IssueRequest[]>>;
     mapRedeemRequests(vaultId: AccountId): Promise<Map<AccountId, RedeemRequest[]>>;
+    mapReplaceRequests(vaultId: AccountId): Promise<Map<AccountId, ReplaceRequest[]>>;
     getPagedIterator(perPage: number): AsyncGenerator<Vault[]>;
     get(vaultId: AccountId): Promise<Vault>;
     getCollateralization(vaultId: AccountId): Promise<number>;

--- a/src/mock/apis/issue.ts
+++ b/src/mock/apis/issue.ts
@@ -63,6 +63,10 @@ export class MockIssueAPI implements IssueAPI {
         ]);
     }
 
+    mapForUser(_account: AccountId): Promise<Map<H256, IssueRequest>> {
+        return Promise.resolve(new Map<H256, IssueRequest>());
+    }
+
     getPagedIterator(_perPage: number): AsyncGenerator<IssueRequest[]> {
         return {} as AsyncGenerator<IssueRequest[]>;
     }

--- a/src/mock/apis/redeem.ts
+++ b/src/mock/apis/redeem.ts
@@ -5,7 +5,6 @@ import { GenericAccountId } from "@polkadot/types/generic";
 import { Bytes, TypeRegistry, u32 } from "@polkadot/types";
 import BN from "bn.js";
 import { U8aFixed } from "@polkadot/types/codec";
-
 import { RedeemAPI } from "../../apis/redeem";
 
 export type RequestResult = { hash: Hash; vault: Vault };
@@ -49,6 +48,10 @@ export class MockRedeemAPI implements RedeemAPI {
                 btc_address: new U8aFixed(registry, "321321321321321") as H160,
             },
         ]);
+    }
+
+    async mapForUser(_account: AccountId): Promise<Map<H256, RedeemRequest>> {
+        return Promise.resolve(new Map<H256, RedeemRequest>());
     }
 
     getPagedIterator(_perPage: number): AsyncGenerator<RedeemRequest[]> {

--- a/src/mock/apis/vaults.ts
+++ b/src/mock/apis/vaults.ts
@@ -1,4 +1,4 @@
-import { IssueRequest, PolkaBTC, RedeemRequest, Vault } from "../../interfaces/default";
+import { IssueRequest, PolkaBTC, RedeemRequest, ReplaceRequest, Vault } from "../../interfaces/default";
 import { AccountId, H160 } from "@polkadot/types/interfaces";
 import { GenericAccountId } from "@polkadot/types/generic";
 import { TypeRegistry } from "@polkadot/types";
@@ -66,6 +66,11 @@ export class MockVaultsAPI implements VaultsAPI {
     async mapRedeemRequests(_vaultId: AccountId): Promise<Map<AccountId, RedeemRequest[]>> {
         // Empty for now, as it is difficult to mock RedeemRequest
         return Promise.resolve(new Map<AccountId, RedeemRequest[]>());
+    }
+
+    async mapReplaceRequests(_vaultId: AccountId): Promise<Map<AccountId, ReplaceRequest[]>> {
+        // Empty for now, as it is difficult to mock ReplaceRequest
+        return Promise.resolve(new Map<AccountId, ReplaceRequest[]>());
     }
 
     getPagedIterator(_perPage: number): AsyncGenerator<Vault[]> {

--- a/test/integration/apis/vaults.test.ts
+++ b/test/integration/apis/vaults.test.ts
@@ -1,11 +1,9 @@
 import { ApiPromise, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
-import { AccountId } from "@polkadot/types/interfaces/runtime";
 import BN from "bn.js";
-import sinon from "sinon";
 import { DefaultVaultsAPI } from "../../../src/apis/vaults";
 import { createPolkadotAPI } from "../../../src/factory";
-import { PolkaBTC, Vault } from "../../../src/interfaces/default";
+import { PolkaBTC } from "../../../src/interfaces/default";
 import { assert } from "../../chai";
 import { defaultEndpoint } from "../../config";
 


### PR DESCRIPTION
The api call cannot be unit tested at the moment, because custom rpc calls are not added to the auto-generated type files. Without rpc types, return values cannot be mocked. I considered manually defining rpc types, but decided it is bad practice. I suppose that in the future polkadot will generate custom rpc type automatically, so this will no longer a problem