### PR TITLE
fix: wrong method name for updateBtcAddress vault call

### DIFF
--- a/src/http/vault.ts
+++ b/src/http/vault.ts
@@ -95,7 +95,7 @@ export class VaultClient extends JsonRpcClient {
         const request = new this.constr["UpdateBtcAddressJsonRpcRequest"](this.registry, {
             address: btcAddress,
         });
-        await this.post("set_btc_address", [request.toHex()]);
+        await this.post("update_btc_address", [request.toHex()]);
     }
 
     async withdrawReplace(replace_id: string): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>