### PR TITLE
feat: Add optional amount and recipient params to op_return query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/polkabtc",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "JavaScript library to interact with PolkaBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/apis/btc-core.ts
+++ b/src/apis/btc-core.ts
@@ -149,8 +149,8 @@ export class DefaultBTCCoreAPI implements BTCCoreAPI {
                 return false;
             }
             if (amountAsBTC) {
-                const amountAsSatoshi = btcToSat(amountAsBTC);
-                if (amountAsSatoshi !== vout.value?.toString()) {
+                const expectedBtcAsSatoshi = Number(btcToSat(amountAsBTC));
+                if (vout.value === undefined || expectedBtcAsSatoshi > vout.value) {
                     return false;
                 }
             }

--- a/src/apis/btc-core.ts
+++ b/src/apis/btc-core.ts
@@ -1,6 +1,7 @@
-import { BlockApi, Status, TxApi, ScripthashApi, Transaction } from "@interlay/esplora-btc-api";
+import { BlockApi, Status, TxApi, ScripthashApi, Transaction, VOut } from "@interlay/esplora-btc-api";
 import { AxiosResponse } from "axios";
 import * as bitcoinjs from "bitcoinjs-lib";
+import { btcToSat } from "../utils/currency";
 
 const mainnetApiBasePath = "https://blockstream.info/api";
 const testnetApiBasePath = "https://electr-testnet.do.polkabtc.io";
@@ -38,7 +39,7 @@ export interface BTCCoreAPI {
     getTransactionStatus(txid: string): Promise<TxStatus>;
     getTransactionBlockHeight(txid: string): Promise<number | undefined>;
     getRawTransaction(txid: string): Promise<Buffer>;
-    getTxIdByOpcode(opcode: string): Promise<string>;
+    getTxIdByOpReturn(opReturn: string, recipientAddress?: string, amountAsBTC?: string): Promise<string>;
 }
 
 export class DefaultBTCCoreAPI implements BTCCoreAPI {
@@ -101,22 +102,26 @@ export class DefaultBTCCoreAPI implements BTCCoreAPI {
     }
 
     /**
-     * Fetch Bitcoin transaction ID based on OP_RETURN field.
+     * Fetch the first bitcoin transaction ID based on the OP_RETURN field, recipient and amount.
      * Throw an error unless there is exactly one transaction with the given opcode.
      *
      * @remarks
      * Performs the lookup using an external service, Esplora. Requires the input string to be a hex
      *
-     * @param opreturn - data string used for matching the OP_CODE of Bitcoin transactions
+     * @param opReturn - Data string used for matching the OP_CODE of Bitcoin transactions
+     * @param recipientAddress - Match the receiving address of a transaction that contains said op_return
+     * @param amountAsBTC - Match the amount (in BTC) of a transaction that contains said op_return and recipientAddress.
+     * This parameter is only considered if `recipientAddress` is defined.
+     *
      * @returns A Bitcoin transaction ID
      */
-    async getTxIdByOpcode(opreturn: string): Promise<string> {
-        const data = Buffer.from(opreturn, "hex");
+    async getTxIdByOpReturn(opReturn: string, recipientAddress?: string, amountAsBTC?: string): Promise<string> {
+        const data = Buffer.from(opReturn, "hex");
         if (data.length !== 32) {
             return Promise.reject("Requires a 32 byte hash as OP_RETURN");
         }
-        const opreturnBuffer = bitcoinjs.script.compile([bitcoinjs.opcodes.OP_RETURN, data]);
-        const hash = bitcoinjs.crypto.sha256(opreturnBuffer).toString("hex");
+        const opReturnBuffer = bitcoinjs.script.compile([bitcoinjs.opcodes.OP_RETURN, data]);
+        const hash = bitcoinjs.crypto.sha256(opReturnBuffer).toString("hex");
 
         let txs: Transaction[] = [];
         try {
@@ -125,14 +130,32 @@ export class DefaultBTCCoreAPI implements BTCCoreAPI {
             console.log(`Error during tx lookup by OP_RETURN: ${e}`);
         }
 
-        if (!txs.length) {
-            return Promise.reject("No transaction id found");
+        for (const tx of txs) {
+            if (tx.vout === undefined) {
+                continue;
+            }
+            for (const vout of tx.vout) {
+                if (this.txOutputHasRecipientAndAmount(vout, recipientAddress, amountAsBTC)) {
+                    return tx.txid;
+                }
+            }
         }
-        if (txs.length > 1) {
-            return Promise.reject("OP_RETURN collision detected");
-        }
+        return Promise.reject("No transaction id found");
+    }
 
-        return txs[0].txid;
+    private txOutputHasRecipientAndAmount(vout: VOut, recipientAddress?: string, amountAsBTC?: string): boolean {
+        if (recipientAddress) {
+            if (recipientAddress !== vout.scriptpubkey_address) {
+                return false;
+            }
+            if (amountAsBTC) {
+                const amountAsSatoshi = btcToSat(amountAsBTC);
+                if (amountAsSatoshi !== vout.value?.toString()) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private getTxStatus(txid: string): Promise<Status> {

--- a/src/mock/apis/btc-core.ts
+++ b/src/mock/apis/btc-core.ts
@@ -61,7 +61,7 @@ export class MockBTCCoreAPI implements BTCCoreAPI {
         );
     }
 
-    getTxIdByOpcode(_opcode: string): Promise<string> {
-        return Promise.resolve("1037930f242763567b7c163e0db4b8e679934aa6317386a455cb6984c81f022d");
+    getTxIdByOpReturn(_opReturn: string, _recipientAddress?: string, _amountAsBTC?: string): Promise<string> {
+        return Promise.resolve("f5bcaeb5181154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91");
     }
 }

--- a/test/integration/apis/btc-core.test.ts
+++ b/test/integration/apis/btc-core.test.ts
@@ -81,8 +81,20 @@ describe("BTCCore testnet", function () {
         it("should return correct tx id", async () => {
             // uses testnet tx: https://blockstream.info/testnet/tx/cac50845f700c97b0e9f0232d2e876e93d384cd93cfa9dc2bf7883ba202237d4?expand
             const opcode = "8703723a787b0f989110b49fd5e1cf1c2571525d564bf384b5aa9e340c9ad8bd";
-            const txid = await btcCore.getTxIdByOpcode(opcode);
+            const txid = await btcCore.getTxIdByOpReturn(opcode);
             assert.strictEqual(txid, "cac50845f700c97b0e9f0232d2e876e93d384cd93cfa9dc2bf7883ba202237d4");
+        });
+
+        it("should return correct tx id when called with amount and receiver", async () => {
+            // uses an op_return that is part of 2 testnet polkaBTC txs, but
+            // only the first one has the queried `amount` parameter
+            // https://blockstream.info/testnet/tx/f5bcaeb5181154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91?expand
+            // https://blockstream.info/testnet/tx/4b1900dc48aaa9fa84a340e94aa21d20b54371d19ea6b8edd68a558cd36afdd0?expand
+            const opReturn = "1165adb125d9703328a37f18b5f8c35732c97a3cd2aab2ead6f28054fd023105";
+            const receiverAddress = "tb1qr959hr9t8zd96w3cqke40da4czqfgmwl0yn5mq";
+            const amountAsBTC = "0.00088";
+            const txid = await btcCore.getTxIdByOpReturn(opReturn, receiverAddress, amountAsBTC);
+            assert.strictEqual(txid, "f5bcaeb5181154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91");
         });
     });
 });
@@ -106,7 +118,7 @@ describe("BTCCore regtest", function () {
         it("should return correct tx id", async () => {
             // FIXME: generate bitcoin transaction with OP_RETURN value
             const opReturnValue = "2e6b22b95a2befa403ad59d0b75d931fd0748cf538b57640826e4692cc4fa24b";
-            const txid = await btcCore.getTxIdByOpcode(opReturnValue);
+            const txid = await btcCore.getTxIdByOpReturn(opReturnValue);
             assert.strictEqual(txid, "829874a7649f6081779071446b8195a550c83431bab4fb9b529a6668ba2f3e22");
         });
     });

--- a/test/unit/apis/btc-core.test.ts
+++ b/test/unit/apis/btc-core.test.ts
@@ -32,11 +32,11 @@ describe.skip("btc-core", () => {
 
     it("should reject getTxByOpcode if query returns empty array", async () => {
         sandbox.stub(DefaultBTCCoreAPI.prototype, "getData").returns(Promise.resolve([]));
-        assert.isRejected(btcCore.getTxIdByOpcode("random"));
+        assert.isRejected(btcCore.getTxIdByOpReturn("random"));
     });
 
     it("should reject getTxByOpcode if query returns array longer than 1", async () => {
         sandbox.stub(DefaultBTCCoreAPI.prototype, "getData").returns(Promise.resolve([undefined, undefined]));
-        assert.isRejected(btcCore.getTxIdByOpcode("random"));
+        assert.isRejected(btcCore.getTxIdByOpReturn("random"));
     });
 });


### PR DESCRIPTION
Tested using an op_return that is part of 2 testnet polkaBTC txs, but only the first one has the queried `amount` parameter:
- https://blockstream.info/testnet/tx/f5bcaeb5181154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91?expand
- https://blockstream.info/testnet/tx/4b1900dc48aaa9fa84a340e94aa21d20b54371d19ea6b8edd68a558cd36afdd0?expand