### PR TITLE
feat(collateral, treasury): Subscribe to balance updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const polkaBTC = await createPolkabtcAPI(defaultParachainEndpoint, isMainnet);
 ```
 
 To emit transactions, an `account` has to be set.
-The account should be an instance of `AddressOrPair`.
+The account should conform to the `IKeyringPair` interface.
 
 ```typescript
 import { createTestKeyring } from "@polkadot/keyring/testing";

--- a/src/parachain/collateral.ts
+++ b/src/parachain/collateral.ts
@@ -1,7 +1,7 @@
 import { AccountId } from "@polkadot/types/interfaces/runtime";
 import { ApiPromise } from "@polkadot/api";
-import { ACCOUNT_NOT_SET_ERROR_MESSAGE, planckToDOT, Transaction } from "../utils";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { ACCOUNT_NOT_SET_ERROR_MESSAGE, dotToPlanck, planckToDOT, Transaction } from "../utils";
+import { IKeyringPair } from "@polkadot/types/types";
 import Big from "big.js";
 /**
  * @category PolkaBTC Bridge
@@ -11,7 +11,7 @@ export interface CollateralAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @returns Total locked collateral
      */
@@ -27,17 +27,24 @@ export interface CollateralAPI {
      */
     balance(id: AccountId): Promise<Big>;
     /**
+     * Subscribe to free balance updates
+     * @param account AccountId string
+     * @param callback Function to be called whenever the balance of an account is updated.
+     * Its parameters are (accountIdString, freeBalance)
+     */
+     subscribeToBalance(account: string, callback: (account: string, balance: Big) => void): Promise<() => void>;
+    /**
      * Send a transaction that transfers from the caller's address to another address
      * @param address The recipient of the transfer
      * @param amount The balance to transfer
      */
-    transfer(address: string, amount: string | number): Promise<void>;
+    transfer(address: string, amount: Big): Promise<void>;
 }
 
 export class DefaultCollateralAPI implements CollateralAPI {
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, private account?: IKeyringPair) {
         this.transaction = new Transaction(api);
     }
 
@@ -59,15 +66,32 @@ export class DefaultCollateralAPI implements CollateralAPI {
         return new Big(planckToDOT(account.free.toString()));
     }
 
-    async transfer(address: string, amount: string | number): Promise<void> {
+    async subscribeToBalance(account: string, callback: (account: string, balance: Big) => void): Promise<() => void> {
+        try {
+            const accountId = this.api.createType("AccountId", account);
+            const unsubscribe = await this.api.query.dot.account(accountId, (balance) => {
+                callback(account, new Big(planckToDOT(balance.free.toString())));
+            });
+            return unsubscribe;
+        } catch (error) {
+            console.log(`Error during collateral balance subscription callback: ${error}`);
+        }
+        // as a fallback, return an empty void function
+        return () => {
+            return;
+        };
+    }
+
+    async transfer(address: string, amount: Big): Promise<void> {
         if (!this.account) {
             return Promise.reject(ACCOUNT_NOT_SET_ERROR_MESSAGE);
         }
-        const transferTx = this.api.tx.dot.transfer(address, amount);
+        const amountSmallDenomination = this.api.createType("Balance", dotToPlanck(amount.toString()));
+        const transferTx = this.api.tx.dot.transfer(address, amountSmallDenomination);
         await this.transaction.sendLogged(transferTx, this.account, this.api.events.dot.Transfer);
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/issue.ts
+++ b/src/parachain/issue.ts
@@ -1,5 +1,5 @@
 import { ApiPromise } from "@polkadot/api";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, H256, Hash } from "@polkadot/types/interfaces";
 import { EventRecord } from "@polkadot/types/interfaces/system";
 import { Bytes } from "@polkadot/types/primitive";
@@ -60,7 +60,7 @@ export interface IssueAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @returns An array containing the issue requests
      */
@@ -107,7 +107,7 @@ export class DefaultIssueAPI implements IssueAPI {
     private feeAPI: FeeAPI;
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: IKeyringPair) {
         this.vaultsAPI = new DefaultVaultsAPI(api, btcNetwork);
         this.feeAPI = new DefaultFeeAPI(api);
         this.transaction = new Transaction(api);
@@ -217,7 +217,7 @@ export class DefaultIssueAPI implements IssueAPI {
         return encodeIssueRequest(await this.api.query.issue.issueRequests.at(head, issueId), this.btcNetwork);
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/oracle.ts
+++ b/src/parachain/oracle.ts
@@ -12,7 +12,7 @@ import {
     storageKeyToFirstInner
 } from "../utils";
 import Big from "big.js";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 
 const defaultFeedName = "DOT/BTC";
 
@@ -69,7 +69,7 @@ export interface OracleAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @returns The Planck/Satoshi exchange rate
      */
@@ -88,7 +88,7 @@ export interface OracleAPI {
 export class DefaultOracleAPI implements OracleAPI {
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, private account?: IKeyringPair) {
         this.transaction = new Transaction(api);
     }
 
@@ -194,7 +194,7 @@ export class DefaultOracleAPI implements OracleAPI {
         return rateBig.div(divisor).toString();
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -1,6 +1,6 @@
 import { PolkaBTC, RedeemRequest, H256Le } from "../interfaces/default";
 import { ApiPromise } from "@polkadot/api";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, Hash, H256, Header } from "@polkadot/types/interfaces";
 import { Bytes } from "@polkadot/types/primitive";
 import { EventRecord } from "@polkadot/types/interfaces/system";
@@ -74,7 +74,7 @@ export interface RedeemAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @param perPage Number of redeem requests to iterate through at a time
      * @returns An AsyncGenerator to be used as an iterator
@@ -146,7 +146,7 @@ export class DefaultRedeemAPI {
     events: EventRecord[] = [];
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: IKeyringPair) {
         this.vaultsAPI = new DefaultVaultsAPI(api, btcNetwork, account);
         this.collateralAPI = new DefaultCollateralAPI(api, account);
         this.transaction = new Transaction(api);
@@ -310,7 +310,7 @@ export class DefaultRedeemAPI {
         return encodeRedeemRequest(await this.api.query.redeem.redeemRequests.at(head, redeemId), this.btcNetwork);
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/refund.ts
+++ b/src/parachain/refund.ts
@@ -1,5 +1,5 @@
 import { ApiPromise } from "@polkadot/api";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, H256 } from "@polkadot/types/interfaces";
 import { Network } from "bitcoinjs-lib";
 import { RefundRequest } from "../interfaces";
@@ -22,7 +22,7 @@ export interface RefundAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @returns An array containing the refund requests
      */
@@ -45,9 +45,9 @@ export interface RefundAPI {
 }
 
 export class DefaultRefundAPI {
-    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: AddressOrPair) { }
+    constructor(private api: ApiPromise, private btcNetwork: Network, private account?: IKeyringPair) { }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 

--- a/src/parachain/replace.ts
+++ b/src/parachain/replace.ts
@@ -5,7 +5,7 @@ import { Hash } from "@polkadot/types/interfaces";
 import { Network } from "bitcoinjs-lib";
 import { ACCOUNT_NOT_SET_ERROR_MESSAGE, encodeBtcAddress, storageKeyToFirstInner, Transaction } from "../utils";
 import { H256 } from "@polkadot/types/interfaces";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { DefaultFeeAPI, FeeAPI } from "./fee";
 import Big from "big.js";
 import { EventRecord } from "@polkadot/types/interfaces/system";
@@ -64,7 +64,7 @@ export interface ReplaceAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * Wihdraw a replace request
      * @param requestId The id of the replace request to withdraw (cancel)
@@ -77,7 +77,7 @@ export class DefaultReplaceAPI implements ReplaceAPI {
     private feeAPI: FeeAPI;
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, btcNetwork: Network, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, btcNetwork: Network, private account?: IKeyringPair) {
         this.btcNetwork = btcNetwork;
         this.feeAPI = new DefaultFeeAPI(api);
         this.transaction = new Transaction(api);
@@ -161,7 +161,7 @@ export class DefaultReplaceAPI implements ReplaceAPI {
         return redeemRequestMap;
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/staked-relayer.ts
+++ b/src/parachain/staked-relayer.ts
@@ -10,7 +10,7 @@ import Big from "big.js";
 import { DefaultOracleAPI, OracleAPI } from "./oracle";
 import { CollateralAPI, DefaultCollateralAPI } from "./collateral";
 import { DefaultFeeAPI, FeeAPI } from "./fee";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { ErrorCode } from "../interfaces/default";
 
 /**
@@ -154,7 +154,7 @@ export interface StakedRelayerAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
 }
 
 export interface PendingStatusUpdate {
@@ -171,7 +171,7 @@ export class DefaultStakedRelayerAPI implements StakedRelayerAPI {
     private feeAPI: FeeAPI;
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, btcNetwork: Network, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, btcNetwork: Network, private account?: IKeyringPair) {
         this.collateralAPI = new DefaultCollateralAPI(api);
         this.oracleAPI = new DefaultOracleAPI(api);
         this.vaultsAPI = new DefaultVaultsAPI(api, btcNetwork);
@@ -408,7 +408,7 @@ export class DefaultStakedRelayerAPI implements StakedRelayerAPI {
         return await this.api.query.stakedRelayers.maturityPeriod.at(head);
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/parachain/treasury.ts
+++ b/src/parachain/treasury.ts
@@ -1,60 +1,85 @@
-import { AccountId, Balance } from "@polkadot/types/interfaces/runtime";
+import { AccountId } from "@polkadot/types/interfaces/runtime";
 import { ApiPromise } from "@polkadot/api";
-import { ACCOUNT_NOT_SET_ERROR_MESSAGE, Transaction } from "../utils";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { ACCOUNT_NOT_SET_ERROR_MESSAGE, btcToSat, satToBTC, Transaction } from "../utils";
+import { IKeyringPair } from "@polkadot/types/types";
+import Big from "big.js";
 
 /**
  * @category PolkaBTC Bridge
  */
 export interface TreasuryAPI {
     /**
-     * @returns The total PolkaBTC issued in the system, denoted in Satoshi
+     * @returns The total amount issued in the system
      */
-    totalPolkaBTC(): Promise<Balance>;
+    total(): Promise<Big>;
     /**
      * @param id The AccountId of a user
-     * @returns The user's PolkaBTC balance, denoted in Satoshi
+     * @returns The user's balance
      */
-    balancePolkaBTC(id: AccountId): Promise<Balance>;
+    balance(id: AccountId): Promise<Big>;
     /**
      * @param destination The address of a user
-     * @param amountSatoshi The amount in satoshi to transfer
+     * @param amount The amount to transfer
      */
-    transfer(destination: string, amountSatoshi: string): Promise<void>;
+    transfer(destination: string, amount: Big): Promise<void>;
     /**
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
+    /**
+     * Subscribe to balance updates
+     * @param account AccountId string
+     * @param callback Function to be called whenever the balance of an account is updated.
+     * Its parameters are (accountIdString, freeBalance)
+     */
+    subscribeToBalance(account: string, callback: (account: string, balance: Big) => void): Promise<() => void>;
 }
 
 export class DefaultTreasuryAPI implements TreasuryAPI {
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, private account?: IKeyringPair) {
         this.transaction = new Transaction(api);
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 
-    async totalPolkaBTC(): Promise<Balance> {
+    async total(): Promise<Big> {
         const head = await this.api.rpc.chain.getFinalizedHead();
-        return this.api.query.polkaBtc.totalIssuance.at(head);
+        const totalBN =  this.api.query.polkaBtc.totalIssuance.at(head);
+        return new Big(satToBTC(totalBN.toString()));
     }
 
-    async balancePolkaBTC(id: AccountId): Promise<Balance> {
+    async balance(id: AccountId): Promise<Big> {
         const account = await this.api.query.polkaBtc.account(id);
-        return account.free;
+        return new Big(satToBTC(account.free.toString()));
     }
 
-    async transfer(destination: string, amountSatoshi: string): Promise<void> {
+    async subscribeToBalance(account: string, callback: (account: string, balance: Big) => void): Promise<() => void> {
+        try {
+            const accountId = this.api.createType("AccountId", account);
+            const unsubscribe = await this.api.query.polkaBtc.account(accountId, (balance) => {
+                callback(account, new Big(satToBTC(balance.free.toString())));
+            });
+            return unsubscribe;
+        } catch (error) {
+            console.log(`Error during treasury balance subscription callback: ${error}`);
+        }
+        // as a fallback, return an empty void function
+        return () => {
+            return;
+        };
+    }
+
+    async transfer(destination: string, amount: Big): Promise<void> {
         if (!this.account) {
             return Promise.reject(ACCOUNT_NOT_SET_ERROR_MESSAGE);
         }
-
-        const transferTransaction = this.api.tx.polkaBtc.transfer(destination, amountSatoshi);
+        const amountSmallDenomination = this.api.createType("Balance", btcToSat(amount.toString()));
+        const transferTransaction = this.api.tx.polkaBtc.transfer(destination, amountSmallDenomination);
         await this.transaction.sendLogged(transferTransaction, this.account, this.api.events.polkaBtc.Transfer);
     }
 }

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -21,7 +21,7 @@ import { ReplaceRequestExt, encodeReplaceRequest } from "./replace";
 import { Network } from "bitcoinjs-lib";
 import { FeeAPI } from "..";
 import { DefaultFeeAPI } from "./fee";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import BN from "bn.js";
 
 export interface WalletExt {
@@ -244,7 +244,7 @@ export interface VaultsAPI {
      * Set an account to use when sending transactions from this API
      * @param account Keyring account
      */
-    setAccount(account: AddressOrPair): void;
+    setAccount(account: IKeyringPair): void;
     /**
      * @param amountAsPlanck Value to withdraw from staking
      */
@@ -271,7 +271,7 @@ export class DefaultVaultsAPI {
     feeAPI: FeeAPI;
     transaction: Transaction;
 
-    constructor(private api: ApiPromise, btcNetwork: Network, private account?: AddressOrPair) {
+    constructor(private api: ApiPromise, btcNetwork: Network, private account?: IKeyringPair) {
         this.btcNetwork = btcNetwork;
         this.collateralAPI = new DefaultCollateralAPI(api);
         this.oracleAPI = new DefaultOracleAPI(api);
@@ -609,7 +609,7 @@ export class DefaultVaultsAPI {
         return this.api.createType("Balance", wrappedBalance.amount.toString());
     }
 
-    setAccount(account: AddressOrPair): void {
+    setAccount(account: IKeyringPair): void {
         this.account = account;
     }
 }

--- a/src/polkabtc-api.ts
+++ b/src/polkabtc-api.ts
@@ -1,7 +1,5 @@
 import { ApiPromise } from "@polkadot/api";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
-import { Signer } from "@polkadot/api/types";
-import { KeyringPair } from "@polkadot/keyring/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { BTCCoreAPI, DefaultBTCCoreAPI } from "./external/btc-core";
 import { DefaultIssueAPI, IssueAPI } from "./parachain/issue";
 import { DefaultOracleAPI, OracleAPI } from "./parachain/oracle";
@@ -47,8 +45,8 @@ export interface PolkaBTCAPI {
     readonly system: SystemAPI;
     readonly replace: ReplaceAPI;
     readonly fee: FeeAPI;
-    setAccount(account: AddressOrPair, signer?: Signer): void;
-    readonly account: AddressOrPair | undefined;
+    setAccount(account: IKeyringPair): void;
+    readonly account: IKeyringPair | undefined;
 }
 
 /**
@@ -70,7 +68,7 @@ export class DefaultPolkaBTCAPI implements PolkaBTCAPI {
     public readonly replace: ReplaceAPI;
     public readonly fee: FeeAPI;
 
-    constructor(readonly api: ApiPromise, network: string = "mainnet", private _account?: AddressOrPair) {
+    constructor(readonly api: ApiPromise, network: string = "mainnet", private _account?: IKeyringPair) {
         const btcNetwork = getBitcoinNetwork(network);
         this.vaults = new DefaultVaultsAPI(api, btcNetwork);
         this.issue = new DefaultIssueAPI(api, btcNetwork, _account);
@@ -88,13 +86,7 @@ export class DefaultPolkaBTCAPI implements PolkaBTCAPI {
         this.fee = new DefaultFeeAPI(api);
     }
 
-    setAccount(account: AddressOrPair, signer?: Signer): void {
-        if (!(account as KeyringPair).sign && !signer) {
-            throw new Error("signer must be passed if account is not a Keypair");
-        }
-        if (signer) {
-            this.api.setSigner(signer);
-        }
+    setAccount(account: IKeyringPair): void {
         this._account = account;
         this.issue.setAccount(account);
         this.redeem.setAccount(account);
@@ -104,7 +96,7 @@ export class DefaultPolkaBTCAPI implements PolkaBTCAPI {
         this.stakedRelayer.setAccount(account);
     }
 
-    get account(): AddressOrPair | undefined {
+    get account(): IKeyringPair | undefined {
         return this._account;
     }
 }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,6 +1,5 @@
-import { AddressOrPair } from "@polkadot/api/submittable/types";
 import { SubmittableExtrinsic } from "@polkadot/api/types";
-import { ISubmittableResult } from "@polkadot/types/types";
+import { ISubmittableResult, IKeyringPair } from "@polkadot/types/types";
 import { EventRecord, DispatchError } from "@polkadot/types/interfaces/system";
 import { ApiPromise } from "@polkadot/api";
 import { IGNORED_ERROR_MESSAGES } from "./constants";
@@ -19,7 +18,7 @@ export interface TransactionAPI {
      */
      sendLogged<T extends AnyTuple>(
         transaction: SubmittableExtrinsic<"promise">,
-        signer: AddressOrPair,
+        signer: IKeyringPair,
         successEventType?: AugmentedEvent<ApiTypes, T>
     ): Promise<ISubmittableResult>;
 }
@@ -29,7 +28,7 @@ export class Transaction implements TransactionAPI {
 
     async sendLogged<T extends AnyTuple>(
         transaction: SubmittableExtrinsic<"promise">,
-        signer: AddressOrPair,
+        signer: IKeyringPair,
         successEventType?: AugmentedEvent<ApiTypes, T>
     ): Promise<ISubmittableResult> {
         // When passing { nonce: -1 } to signAndSend the API will use system.accountNextIndex to determine the nonce
@@ -110,7 +109,7 @@ export class Transaction implements TransactionAPI {
         });
         return true;
     }
-    
+
     isDispatchError(eventData: unknown): eventData is DispatchError {
         return (eventData as DispatchError).isModule !== undefined;
     }

--- a/test/integration/parachain/staging/collateral.test.ts
+++ b/test/integration/parachain/staging/collateral.test.ts
@@ -1,0 +1,59 @@
+import { ApiPromise, Keyring } from "@polkadot/api";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { DefaultCollateralAPI, CollateralAPI } from "../../../../src/parachain/collateral";
+import { createPolkadotAPI } from "../../../../src/factory";
+import { assert } from "../../../chai";
+import { defaultParachainEndpoint } from "../../../config";
+import Big from "big.js";
+
+describe("CollateralAPI", () => {
+    let api: ApiPromise;
+    let collateral: CollateralAPI;
+    let alice: KeyringPair;
+    let bob: KeyringPair;
+
+    before(async () => {
+        api = await createPolkadotAPI(defaultParachainEndpoint);
+        const keyring = new Keyring({ type: "sr25519" });
+        alice = keyring.addFromUri("//Alice");
+        bob = keyring.addFromUri("//Bob");
+        collateral = new DefaultCollateralAPI(api, alice);
+    });
+
+    after(() => {
+        return api.disconnect();
+    });
+
+    describe("Collateral", () => {
+        it("should subscribe to collateral balanace updates", async () => {
+            // Subscribe and receive two balance updates
+
+            let updatedBalance = new Big(0);
+            let updatedAccount = "";
+            function balanceUpdateCallback(account: string, newBalance: Big) {
+                updatedBalance = newBalance;
+                updatedAccount = account;
+            }
+            const amountToUpdateBobsAccountBy = new Big(1);
+            const bobBalanceBeforeTransfer = 
+                await collateral.balance(api.createType("AccountId", bob.address));
+            const unsubscribe = await collateral.subscribeToBalance(bob.address, balanceUpdateCallback);
+
+            // Send the first transfer, expect the callback to be called with correct values
+            await collateral.transfer(bob.address, amountToUpdateBobsAccountBy);
+            assert.equal(updatedAccount, bob.address);
+            const expectedBobBalanceAfterFirstTransfer = bobBalanceBeforeTransfer.add(amountToUpdateBobsAccountBy);
+            assert.equal(updatedBalance.toString(), expectedBobBalanceAfterFirstTransfer.toString());
+
+            // Send the second transfer, expect the callback to be called with correct values
+            await collateral.transfer(bob.address, amountToUpdateBobsAccountBy);
+            assert.equal(updatedAccount, bob.address);
+            const expectedBobBalanceAfterSecondTransfer = expectedBobBalanceAfterFirstTransfer.add(amountToUpdateBobsAccountBy);
+            assert.equal(updatedBalance.toString(), expectedBobBalanceAfterSecondTransfer.toString());
+            
+            unsubscribe();
+        });
+    });
+
+});
+

--- a/test/integration/parachain/staging/issue.test.ts
+++ b/test/integration/parachain/staging/issue.test.ts
@@ -93,6 +93,8 @@ describe("issue", () => {
             await assert.isRejected(tmpIssueAPI.execute(issueId, txId, merkleProof, rawTx));
         });
 
+        // auto-execution tests may stall indefinitely, due to vault client inaction.
+        // This will cause the testing pipeline to time out.
         it("should request and auto-execute issue", async () => {
             const amount = "0.001";
             const issueResult = await issue(

--- a/test/integration/parachain/staging/redeem.test.ts
+++ b/test/integration/parachain/staging/redeem.test.ts
@@ -11,7 +11,7 @@ import { btcToSat, stripHexPrefix, satToBTC } from "../../../../src/utils";
 import * as bitcoin from "bitcoinjs-lib";
 import { DefaultTreasuryAPI } from "../../../../src/parachain/treasury";
 import { BitcoinCoreClient } from "../../../utils/bitcoin-core-client";
-import BN from "bn.js";
+import Big from "big.js";
 
 export type RequestResult = { hash: Hash; vault: Vault };
 
@@ -121,17 +121,15 @@ describe("redeem", () => {
         }
 
         it("should request and execute issue, request (and wait for execute) redeem", async () => {
-            const initialBalance = await treasuryAPI.balancePolkaBTC(api.createType("AccountId", alice.address));
+            const initialBalance = await treasuryAPI.balance(api.createType("AccountId", alice.address));
             const blocksToMine = 3;
-            const amountAsBtcString = "0.1";
-            const redeemAmountAsBtcString = "0.09";
-            await requestAndCallRedeem(blocksToMine, amountAsBtcString, redeemAmountAsBtcString);
+            const issueAmount = new Big("0.1");
+            const redeemAmount = new Big("0.09");
+            await requestAndCallRedeem(blocksToMine, issueAmount.toString(), redeemAmount.toString());
 
             // check redeeming worked
-            const issueAmountAsSatoshi = new BN(btcToSat(amountAsBtcString));
-            const redeemAmountAsSatoshi = new BN(btcToSat(redeemAmountAsBtcString));
-            const expectedBalanceDifferenceAfterRedeem = issueAmountAsSatoshi.sub(redeemAmountAsSatoshi);
-            const finalBalance = await treasuryAPI.balancePolkaBTC(api.createType("AccountId", alice.address));
+            const expectedBalanceDifferenceAfterRedeem = issueAmount.sub(redeemAmount);
+            const finalBalance = await treasuryAPI.balance(api.createType("AccountId", alice.address));
             assert.equal(initialBalance.add(expectedBalanceDifferenceAfterRedeem).toString(), finalBalance.toString());
         }).timeout(1000000);
     });

--- a/test/integration/parachain/staging/treasury.test.ts
+++ b/test/integration/parachain/staging/treasury.test.ts
@@ -1,0 +1,59 @@
+import { ApiPromise, Keyring } from "@polkadot/api";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { DefaultTreasuryAPI, TreasuryAPI } from "../../../../src/parachain/treasury";
+import { createPolkadotAPI } from "../../../../src/factory";
+import { assert } from "../../../chai";
+import { defaultParachainEndpoint } from "../../../config";
+import Big from "big.js";
+
+describe("TreasuryAPI", () => {
+    let api: ApiPromise;
+    let treasury: TreasuryAPI;
+    let alice: KeyringPair;
+    let bob: KeyringPair;
+
+    before(async () => {
+        api = await createPolkadotAPI(defaultParachainEndpoint);
+        const keyring = new Keyring({ type: "sr25519" });
+        alice = keyring.addFromUri("//Alice");
+        bob = keyring.addFromUri("//Bob");
+        treasury = new DefaultTreasuryAPI(api, alice);
+    });
+
+    after(() => {
+        return api.disconnect();
+    });
+
+    describe("Treasury", () => {
+        it("should subscribe to treasury balanace updates", async () => {
+            // Subscribe and receive two balance updates
+
+            let updatedBalance = new Big(0);
+            let updatedAccount = "";
+            function balanceUpdateCallback(account: string, newBalance: Big) {
+                updatedBalance = newBalance;
+                updatedAccount = account;
+            }
+            const amountToUpdateBobsAccountBy = new Big(0.00000001);
+            const bobBalanceBeforeTransfer = 
+                await treasury.balance(api.createType("AccountId", bob.address));
+            const unsubscribe = await treasury.subscribeToBalance(bob.address, balanceUpdateCallback);
+
+            // Send the first transfer, expect the callback to be called with correct values
+            await treasury.transfer(bob.address, amountToUpdateBobsAccountBy);
+            assert.equal(updatedAccount, bob.address);
+            const expectedBobBalanceAfterFirstTransfer = bobBalanceBeforeTransfer.add(amountToUpdateBobsAccountBy);
+            assert.equal(updatedBalance.toString(), expectedBobBalanceAfterFirstTransfer.toString());
+
+            // Send the second transfer, expect the callback to be called with correct values
+            await treasury.transfer(bob.address, amountToUpdateBobsAccountBy);
+            assert.equal(updatedAccount, bob.address);
+            const expectedBobBalanceAfterSecondTransfer = expectedBobBalanceAfterFirstTransfer.add(amountToUpdateBobsAccountBy);
+            assert.equal(updatedBalance.toString(), expectedBobBalanceAfterSecondTransfer.toString());
+            
+            unsubscribe();
+        });
+    });
+
+});
+

--- a/test/mock/parachain/collateral.ts
+++ b/test/mock/parachain/collateral.ts
@@ -1,9 +1,13 @@
 import { AccountId } from "@polkadot/types/interfaces/runtime";
 import { CollateralAPI } from "../../../src/parachain/collateral";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import Big from "big.js";
 
 export class MockCollateralAPI implements CollateralAPI {
+    subscribeToBalance(_account: string, _callback: (account: string, balance: Big) => void): Promise<() => void> {
+        throw new Error("Method not implemented.");
+    }
+
     async totalLocked(): Promise<Big> {
         return new Big("10");
     }
@@ -16,11 +20,11 @@ export class MockCollateralAPI implements CollateralAPI {
         return new Big("5");
     }
 
-    async transfer(_address: string, _amount: string | number): Promise<void> {
+    async transfer(_address: string, _amount: Big): Promise<void> {
         return;
     }
 
-    setAccount(_account?: AddressOrPair): void {
+    setAccount(_account?: IKeyringPair): void {
         return;
     }
 }

--- a/test/mock/parachain/issue.ts
+++ b/test/mock/parachain/issue.ts
@@ -1,5 +1,5 @@
 import { DOT, IssueRequest, PolkaBTC, H256Le } from "../../../src/interfaces/default";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, H256, BlockNumber, Hash } from "@polkadot/types/interfaces";
 import { Bytes, bool } from "@polkadot/types/primitive";
 import BN from "bn.js";
@@ -25,7 +25,7 @@ export class MockIssueAPI implements IssueAPI {
         return Promise.resolve({ id, issueRequest: (await this.list())[0] });
     }
 
-    setAccount(_account?: AddressOrPair): void {
+    setAccount(_account?: IKeyringPair): void {
         return;
     }
 

--- a/test/mock/parachain/oracle.ts
+++ b/test/mock/parachain/oracle.ts
@@ -1,4 +1,4 @@
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { OracleAPI } from "../../../src/parachain";
 import { BtcTxFees } from "../../../src/parachain/oracle";
 import Big from "big.js";
@@ -49,7 +49,7 @@ export class MockOracleAPI implements OracleAPI {
         return;
     }
 
-    async setAccount(_account: AddressOrPair): Promise<void> {
+    async setAccount(_account: IKeyringPair): Promise<void> {
         return;
     }
 }

--- a/test/mock/parachain/redeem.ts
+++ b/test/mock/parachain/redeem.ts
@@ -1,5 +1,5 @@
 import { PolkaBTC, RedeemRequest, DOT, H256Le } from "../../../src/interfaces/default";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, Hash, BlockNumber, H256 } from "@polkadot/types/interfaces";
 import { GenericAccountId } from "@polkadot/types/generic";
 import { Bytes, TypeRegistry, u32 } from "@polkadot/types";
@@ -79,7 +79,7 @@ export class MockRedeemAPI implements RedeemAPI {
         return Promise.resolve(new BN(1) as PolkaBTC);
     }
 
-    setAccount(_account?: AddressOrPair): void {
+    setAccount(_account?: IKeyringPair): void {
         return;
     }
 

--- a/test/mock/parachain/refund.ts
+++ b/test/mock/parachain/refund.ts
@@ -1,5 +1,5 @@
 import { PolkaBTC } from "../../../src/interfaces/default";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { AccountId, H256 } from "@polkadot/types/interfaces";
 import { GenericAccountId } from "@polkadot/types/generic";
 
@@ -12,7 +12,7 @@ export class MockRefundAPI implements RefundAPI {
         return Promise.resolve([]);
     }
 
-    setAccount(_account?: AddressOrPair): void {
+    setAccount(_account?: IKeyringPair): void {
         return;
     }
 

--- a/test/mock/parachain/replace.ts
+++ b/test/mock/parachain/replace.ts
@@ -4,14 +4,14 @@ import { PolkaBTC, DOT } from "../../../src/interfaces/default";
 import BN from "bn.js";
 import { ReplaceRequestExt } from "../../../src/parachain/replace";
 import { AccountId } from "@polkadot/types/interfaces";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 
 export class MockReplaceAPI implements ReplaceAPI {
     withdraw(_requestId: string): Promise<void> {
         return Promise.resolve();
     }
     
-    setAccount(_account: AddressOrPair): void {
+    setAccount(_account: IKeyringPair): void {
         return;
     }
     

--- a/test/mock/parachain/staked-relayer.ts
+++ b/test/mock/parachain/staked-relayer.ts
@@ -7,7 +7,7 @@ import { TypeRegistry } from "@polkadot/types";
 import { GenericAccountId } from "@polkadot/types/generic";
 import { PendingStatusUpdate, StakedRelayerAPI } from "../../../src/parachain/staked-relayer";
 import Big from "big.js";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 
 function createStatusUpdate(): { id: u256; statusUpdate: StatusUpdate } {
     const registry = new TypeRegistry();
@@ -39,7 +39,7 @@ export class MockStakedRelayerAPI implements StakedRelayerAPI {
         return Promise.resolve();
     }
 
-    setAccount(_account: AddressOrPair): void {
+    setAccount(_account: IKeyringPair): void {
         return;
     }
 

--- a/test/mock/parachain/treasury.ts
+++ b/test/mock/parachain/treasury.ts
@@ -1,25 +1,26 @@
-import { AccountId, Balance } from "@polkadot/types/interfaces/runtime";
+import { AccountId } from "@polkadot/types/interfaces/runtime";
 import { TreasuryAPI } from "../../../src/parachain/treasury";
-import { u128 } from "@polkadot/types/primitive";
-import { TypeRegistry } from "@polkadot/types";
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
+import Big from "big.js";
 
 export class MockTreasuryAPI implements TreasuryAPI {
-    async totalPolkaBTC(): Promise<Balance> {
-        const registry = new TypeRegistry();
-        return new u128(registry, 128);
+    subscribeToBalance(_account: string, _callback: (account: string, balance: Big) => void): Promise<() => void> {
+        throw new Error("Method not implemented.");
+    }
+    
+    async total(): Promise<Big> {
+        return new Big(199);
     }
 
-    async balancePolkaBTC(_id: AccountId): Promise<Balance> {
-        const registry = new TypeRegistry();
-        return new u128(registry, 128);
+    async balance(_id: AccountId): Promise<Big> {
+        return new Big(100);
     }
 
-    async transfer(_destination: string, _amountSatoshi: string): Promise<void> {
+    async transfer(_destination: string, _amount: Big): Promise<void> {
         return;
     }
 
-    setAccount(_account: AddressOrPair): void {
+    setAccount(_account: IKeyringPair): void {
         return;
     }
 }

--- a/test/mock/parachain/vaults.ts
+++ b/test/mock/parachain/vaults.ts
@@ -10,7 +10,7 @@ import { RedeemRequestExt } from "../../../src/parachain/redeem";
 import { ReplaceRequestExt } from "../../../src/parachain/replace";
 import { VaultsAPI, VaultExt } from "../../../src/parachain/vaults";
 import Big from "big.js";
-import { AddressOrPair } from "@polkadot/api/types";
+import { IKeyringPair } from "@polkadot/types/types";
 
 export class MockVaultsAPI implements VaultsAPI {
     getLiquidationVaultId(): Promise<string> {
@@ -19,7 +19,7 @@ export class MockVaultsAPI implements VaultsAPI {
     getLiquidationVault(): Promise<SystemVault> {
         throw new Error("Method not implemented.");
     }
-    setAccount(_account: AddressOrPair): void {
+    setAccount(_account: IKeyringPair): void {
         return;
     }
 

--- a/test/mock/polkabtc-api.ts
+++ b/test/mock/polkabtc-api.ts
@@ -1,4 +1,4 @@
-import { AddressOrPair } from "@polkadot/api/submittable/types";
+import { IKeyringPair } from "@polkadot/types/types";
 import { ApiPromise } from "@polkadot/api";
 import { Signer } from "@polkadot/api/types";
 
@@ -49,7 +49,7 @@ export default class MockPolkaBTCAPI implements PolkaBTCAPI {
     public readonly refund: RefundAPI;
     public readonly fee: FeeAPI;
 
-    constructor(readonly api: ApiPromise, private _account?: AddressOrPair) {
+    constructor(readonly api: ApiPromise, private _account?: IKeyringPair) {
         this.vaults = new MockVaultsAPI();
         this.issue = new MockIssueAPI();
         this.redeem = new MockRedeemAPI();
@@ -66,11 +66,11 @@ export default class MockPolkaBTCAPI implements PolkaBTCAPI {
         this.fee = new MockFeeAPI();
     }
 
-    setAccount(account: AddressOrPair, _signer?: Signer): void {
+    setAccount(account: IKeyringPair, _signer?: Signer): void {
         this._account = account;
     }
 
-    get account(): AddressOrPair | undefined {
+    get account(): IKeyringPair | undefined {
         return this._account;
     }
 }

--- a/test/unit/polkabtc-api.test.ts
+++ b/test/unit/polkabtc-api.test.ts
@@ -2,14 +2,11 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { assert } from "../chai";
 import sinon from "sinon";
 import { DefaultPolkaBTCAPI, PolkaBTCAPI } from "../../src/polkabtc-api";
-import { SingleAccountSigner } from "../utils/SingleAccountSigner";
-import { createAPIRegistry } from "../../src/factory";
 
 describe("PolkaBTCAPI", () => {
     const keyring = new Keyring();
     const keyringPair = keyring.addFromUri("//Bob");
     let polkaBTC: PolkaBTCAPI;
-    const registry = createAPIRegistry();
 
     beforeEach(async () => {
         const api = sinon.createStubInstance(ApiPromise);
@@ -24,13 +21,8 @@ describe("PolkaBTCAPI", () => {
         });
 
         it("should succeed to set address with signer", () => {
-            const signer = new SingleAccountSigner(registry, keyringPair);
-            polkaBTC.setAccount(keyringPair.address, signer);
+            polkaBTC.setAccount(keyringPair);
             assert.isDefined(polkaBTC.account);
-        });
-
-        it("should fail to set address without signer", () => {
-            assert.throw(() => polkaBTC.setAccount(keyringPair.address));
         });
     });
 });

--- a/test/utils/issue.ts
+++ b/test/utils/issue.ts
@@ -36,7 +36,7 @@ export async function issue(
     issueAPI.setAccount(requester);
     const requesterAccountId = api.createType("AccountId", requester.address);
     const initialBalanceDOT = await collateralAPI.balance(requesterAccountId);
-    const initialBalancePolkaBTC = await treasuryAPI.balancePolkaBTC(requesterAccountId);
+    const initialBalancePolkaBTC = await treasuryAPI.balance(requesterAccountId);
     const blocksToMine = 3;
     keyring = new Keyring({ type: "sr25519" });
     const vault = keyring.addFromUri("//" + vaultName);
@@ -92,7 +92,7 @@ export async function issue(
     }
 
     // check issuing worked
-    const finalBalancePolkaBTC = await treasuryAPI.balancePolkaBTC(requesterAccountId);
+    const finalBalancePolkaBTC = await treasuryAPI.balance(requesterAccountId);
 
     const finalBalanceDOT = await collateralAPI.balance(requesterAccountId);
 


### PR DESCRIPTION
Also constrains set accounts to be of type `IKeyringPair` instead of `AddressOrPair`, to remove ambiguity and ensure transactions can be signed with it. While not being very significant, this change touches many files.

I'm thinking of removing the `setAccount` pattern entirely and having the signer passed as a parameter. This would remove the is-account-set checks (e.g. here https://github.com/interlay/polkabtc-js/blob/master/src/parachain/issue.ts#L132) which are thrown if a transaction call is copy-pasted to a place where the API account isn't already set.