### PR TITLE
fix: use hex encoding for raw transactions to prevent byte conversion…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/polkabtc",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "description": "JavaScript library to interact with PolkaBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -74,9 +74,9 @@ export interface ElectrsAPI {
     getTransactionBlockHeight(txid: string): Promise<number | undefined>;
     /**
      * @param txid The ID of a Bitcoin transaction
-     * @returns The raw transaction data, represented as a Buffer object
+     * @returns The raw transaction data, represented as a hex string
      */
-    getRawTransaction(txid: string): Promise<Buffer>;
+    getRawTransaction(txid: string): Promise<string>;
     /**
      * Fetch the first bitcoin transaction ID based on the OP_RETURN field, recipient and amount.
      * Throw an error unless there is exactly one transaction with the given opcode.
@@ -140,7 +140,7 @@ export interface ElectrsAPI {
      */
     getParsedExecutionParameters(txid: string): Promise<[Bytes, Bytes]>;
     /**
-     * Return a promise that either resolves to the first txid with the given opreturn `data`, 
+     * Return a promise that either resolves to the first txid with the given opreturn `data`,
      * or rejects if the `timeout` has elapsed.
      *
      * @remarks
@@ -353,16 +353,16 @@ export class DefaultElectrsAPI implements ElectrsAPI {
         ]);
         // To avoid taking an ApiPromise object as a constructor parameter,
         // use the default TypeRegistry (without custom type metadata),
-        // because the Bytes type instantiated is provided by default. 
+        // because the Bytes type instantiated is provided by default.
         const registry = new TypeRegistry();
-        
+
         const merkleProof = registry.createType("Bytes", "0x" + unparsedMerkleProof);
-        const rawTx = registry.createType("Bytes", "0x" + unparsedRawTx.toString("hex"));
+        const rawTx = registry.createType("Bytes", "0x" + unparsedRawTx);
         return [merkleProof, rawTx];
     }
 
-    getRawTransaction(txid: string): Promise<Buffer> {
-        return this.getData(this.txApi.getTxRaw(txid, { responseType: "arraybuffer" }));
+    getRawTransaction(txid: string): Promise<string> {
+        return this.getData(this.txApi.getTxHex(txid));
     }
 
     /**

--- a/test/integration/external/staging/electrs.test.ts
+++ b/test/integration/external/staging/electrs.test.ts
@@ -52,18 +52,16 @@ describe("ElectrsAPI testnet", function () {
 
     it("should return correct raw tx", async () => {
         // eslint-disable-next-line max-len
-        const raw = Buffer.from(
+        const raw =
             "020000000001012a489eaa754d9aaf5198627d79e9234dba945436" +
-                    "503aa445c1b82d6bc194c3270100000000ffffffff028038010000" +
-                    "0000001600145601eeffa54c8b7e306c0b3a50c48121c42d09be8d" +
-                    "4e030000000000160014a528e6f91766262e3d1b22e52af342f55b" +
-                    "2d551c0247304402206fdaa5186ff79740b0fc2848f3ee40b48aa0" +
-                    "cbdf9000304fbe6d35d7b1ee0c3602202cf90c73b0b834c8cc78c0" +
-                    "b9e988bc2c5781fa617551c8cb5aa7b555efe7ab0a012102170f80" +
-                    "797baa55d091f85e38a7b463c56905c09ef6024e83039037be5cd7" +
-                    "550900000000",
-            "hex"
-        );
+            "503aa445c1b82d6bc194c3270100000000ffffffff028038010000" +
+            "0000001600145601eeffa54c8b7e306c0b3a50c48121c42d09be8d" +
+            "4e030000000000160014a528e6f91766262e3d1b22e52af342f55b" +
+            "2d551c0247304402206fdaa5186ff79740b0fc2848f3ee40b48aa0" +
+            "cbdf9000304fbe6d35d7b1ee0c3602202cf90c73b0b834c8cc78c0" +
+            "b9e988bc2c5781fa617551c8cb5aa7b555efe7ab0a012102170f80" +
+            "797baa55d091f85e38a7b463c56905c09ef6024e83039037be5cd7" +
+            "550900000000";
         const raw_tx = await electrsAPI.getRawTransaction(txid);
         assert.deepEqual(raw_tx, raw);
     });
@@ -126,12 +124,7 @@ describe("ElectrsAPI regtest", function () {
         const opReturnValue = "01234567891154267bf7d05901cc8c2f647414a42126c3aee89e01a2c905ae91";
         const recipientAddress = "bcrt1qefxeckts7tkgz7uach9dnwer4qz5nyehl4sjcc";
         const amount = new Big("0.00029");
-        const txData = await bitcoinCoreClient.sendBtcTxAndMine(
-            recipientAddress,
-            amount,
-            6,
-            opReturnValue
-        );
+        const txData = await bitcoinCoreClient.sendBtcTxAndMine(recipientAddress, amount, 6, opReturnValue);
         const txid = await electrsAPI.getTxIdByOpReturn(opReturnValue, recipientAddress, amount);
         assert.strictEqual(txid, txData.txid);
     });

--- a/test/mock/external/electrs.ts
+++ b/test/mock/external/electrs.ts
@@ -61,25 +61,23 @@ export class MockElectrsAPI implements ElectrsAPI {
             version: 1,
         });
     }
-    
+
     getUtxoAmount(_txid: string, _recipient: string): Promise<number> {
         return Promise.resolve(1);
     }
 
-    getRawTransaction(): Promise<Buffer> {
+    getRawTransaction(): Promise<string> {
         return Promise.resolve(
-            Buffer.from(
-                "020000000001012a489eaa754d9aaf5198627d79e9234" +
-                    "dba945436503aa445c1b82d6bc194c3270100000000ff" +
-                    "ffffff0280380100000000001600145601eeffa54c8b7" +
-                    "e306c0b3a50c48121c42d09be8d4e0300000000001600" +
-                    "14a528e6f91766262e3d1b22e52af342f55b2d551c024" +
-                    "7304402206fdaa5186ff79740b0fc2848f3ee40b48aa0" +
-                    "cbdf9000304fbe6d35d7b1ee0c3602202cf90c73b0b83" +
-                    "4c8cc78c0b9e988bc2c5781fa617551c8cb5aa7b555ef" +
-                    "e7ab0a012102170f80797baa55d091f85e38a7b463c56" +
-                    "905c09ef6024e83039037be5cd7550900000000"
-            )
+            "020000000001012a489eaa754d9aaf5198627d79e9234" +
+                "dba945436503aa445c1b82d6bc194c3270100000000ff" +
+                "ffffff0280380100000000001600145601eeffa54c8b7" +
+                "e306c0b3a50c48121c42d09be8d4e0300000000001600" +
+                "14a528e6f91766262e3d1b22e52af342f55b2d551c024" +
+                "7304402206fdaa5186ff79740b0fc2848f3ee40b48aa0" +
+                "cbdf9000304fbe6d35d7b1ee0c3602202cf90c73b0b83" +
+                "4c8cc78c0b9e988bc2c5781fa617551c8cb5aa7b555ef" +
+                "e7ab0a012102170f80797baa55d091f85e38a7b463c56" +
+                "905c09ef6024e83039037be5cd7550900000000"
         );
     }
 


### PR DESCRIPTION
… errors with polkadot createType

Error documentation:

Transaction `c0b28e6c2a2fa8032ceee4fa003717a60a9cf252c25a32fb73d4a2cb4e07b114` should be converted from the following raw hex:
```
02000000000103dc7263d18644c9234b0620032e27eb2c652a8d6d39f347db0be459a11415fc0f0100000000fdffffff7d415392c3df2a982a721d8b5079f8d673146f59523e6ecacfbf2d9dce5671b00100000000fdffffffb27143bb1715aa10fbc6a30f277f5c1b831b24fc7415169fe6709a359f316ff40100000000fdffffff01f88f040000000000160014fad15e169c6289106f53603e0428a17a0533efae02473044022023ea638d27e0bc002224afb3c3ec816c32bae0bb4373e3dbde676e3d22dbb67402200ea07f629af09df2c0c2f70d8be7a0032b764df40ab493639b487dfd1a1686b1012102da170e203f1bfe2c2f32fd751da516fee2879a86e061a9e325467187c1372a2d0247304402205a23fe1423d8e1c0b76349af177c6720e08927536c57da3ce0a45af59eb992c702203aad3ccea9ac8115c6f2d3f8c7ad69ba86645f9169f516e3a274a17b2089d96b012102d1f8529c7e9957bb76151891ed3383222254c64847dec7682fcfb1474c950615024730440220051aa7ef1731899f6cc043d0bf98be4c21d58ddcb8b0236d2ac25288d2821002022079a526b71ae51d7fec59a61d9d75426a4bdfd18b508fb16c997a6a65fcf4d1b10121033a02dd7d23668badf2224e840f1b54b432bde40be4acae3f84c54502fdd36b62d2851e00
```

However, using an ArrayBuffer mistakenly converts this to a 22-byte object instead of the desired 487-byte object.
